### PR TITLE
Discussions の通知内容を修正

### DIFF
--- a/.github/workflows/discussions-notice.yml
+++ b/.github/workflows/discussions-notice.yml
@@ -9,10 +9,50 @@ jobs:
     if: github.event.discussion && !github.event.comment
     steps:
       - run: |
-          curl -X POST -d '{ "text": "Created discussion: ${{ github.event.discussion.html_url }}" }' ${{ secrets.SLACK_WEBHOOK_URL }}
+          curl -X POST ${{ secrets.SLACK_WEBHOOK_URL }} \
+          -H 'Content-Type: application/json' \
+          -d @- << EOF
+          {
+            "text": "*${{ github.event.discussion.user.login }}* が Discussions を作成しました",
+            "attachments": [
+              {
+                "color": "#CCCCCC",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*<${{ github.event.discussion.user.html_url }}|${{ github.event.discussion.user.login }}>*\n${{ github.event.discussion.body }}",
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
   discussion_commented:
     runs-on: ubuntu-latest
     if: github.event.discussion && github.event.comment
     steps:
       - run: |
-          curl -X POST -d '{ "text": "Created discussion comment: ${{ github.event.comment.html_url }}" }' ${{ secrets.SLACK_WEBHOOK_URL }}
+          curl -X POST ${{ secrets.SLACK_WEBHOOK_URL }} \
+          -H 'Content-Type: application/json' \
+          -d @- << EOF
+          {
+            "text": "*<${{ github.event.comment.user.html_url }}|${{ github.event.comment.user.login }}>* が Discussions にコメントしました",
+            "attachments": [
+              {
+                "color": "#CCCCCC",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*<${{ github.event.comment.html_url }}|${{ github.event.discussion.title }}>*\n${{ github.event.comment.body }}",
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+          EOF

--- a/.github/workflows/discussions-notice.yml
+++ b/.github/workflows/discussions-notice.yml
@@ -13,7 +13,7 @@ jobs:
           -H 'Content-Type: application/json' \
           -d @- << EOF
           {
-            "text": "*${{ github.event.discussion.user.login }}* が Discussions を作成しました",
+            "text": "*<${{ github.event.discussion.user.html_url }}|${{ github.event.discussion.user.login }}>* が Discussions を作成しました",
             "attachments": [
               {
                 "color": "#CCCCCC",
@@ -22,7 +22,7 @@ jobs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "*<${{ github.event.discussion.user.html_url }}|${{ github.event.discussion.user.login }}>*\n${{ github.event.discussion.body }}",
+                      "text": "*<${{ github.event.discussion.html_url }}|${{ github.event.discussion.title }}>*\n${{ github.event.discussion.body }}",
                     }
                   }
                 ]


### PR DESCRIPTION
## Why
https://github.com/topotal/waroom/issues/917

## What
通知内容を内容とAuthorが分かるように修正。
こんな感じの通知が Discussions の作成とコメント時に届くようになります。
![image](https://user-images.githubusercontent.com/3971271/209325922-988b9efa-9fb0-41ab-9628-2c8c2f9f2509.png)
